### PR TITLE
Limit seeding speed to minimal

### DIFF
--- a/aria.sh
+++ b/aria.sh
@@ -2,4 +2,4 @@ export MAX_DOWNLOAD_SPEED=0
 aria2c --enable-rpc --rpc-listen-all=false --rpc-listen-port 6800 \
   --max-connection-per-server=10 --rpc-max-request-size=1024M \
   --seed-time=0.01 --min-split-size=10M --follow-torrent=mem --split=10 \
-   --daemon=true --allow-overwrite=true --max-overall-download-limit=$MAX_DOWNLOAD_SPEED max-overall-upload-limit=1K
+   --daemon=true --allow-overwrite=true --max-overall-download-limit=$MAX_DOWNLOAD_SPEED --max-overall-upload-limit=1K


### PR DESCRIPTION
By default aria2 seeds the torrent after downloading it which can cause very high bandwidth consumption and since there is no option to disable seeding (Curse you aria2) this will limit the aria2 upload speed to 1kBps.