### PR TITLE
fs_utils.py: Use python-magic for guessing mimetype

### DIFF
--- a/bot/helper/ext_utils/fs_utils.py
+++ b/bot/helper/ext_utils/fs_utils.py
@@ -3,7 +3,7 @@ from bot import aria2, LOGGER, DOWNLOAD_DIR
 import shutil
 import os
 import pathlib
-import mimetypes
+import magic
 
 
 def clean_download(path: str):
@@ -39,6 +39,7 @@ def tar(orig_path: str):
 
 
 def get_mime_type(file_path):
-    mime_type = mimetypes.guess_type(file_path)[0]
+    mime = magic.Magic(mime=True)
+    mime_type = mime.from_file(file_path)
     mime_type = mime_type if mime_type else "text/plain"
     return mime_type

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ google-auth-oauthlib>=0.4.1,<0.10.0
 aria2p>=0.3.0,<0.10.0
 python-dotenv>=0.10
 tenacity>=6.0.0 
+python-magic


### PR DESCRIPTION
1. mimetypes is not a reliable way to know the mime type of a file.

2. python-magic uses libmagic which identifies file types by checking their headers according to a predefined list of file types.

	https://github.com/ahupp/python-magic