### PR TITLE
clone: handle links with "view" in them

### DIFF
--- a/bot/helper/mirror_utils/upload_utils/gdriveTools.py
+++ b/bot/helper/mirror_utils/upload_utils/gdriveTools.py
@@ -68,6 +68,8 @@ class GoogleDriveHelper:
     def getIdFromUrl(link: str):
         if "folders" in link or "file" in link:
             return link.rsplit('/')[-1]
+        if "view" in link:
+            return link.rsplit('/')[-2]
         parsed = urlparse.urlparse(link)
         return parse_qs(parsed.query)['id'][0]
 


### PR DESCRIPTION
Handle Gdrive Links With "view" In The URL
thanks to @anshuman852 for this fix