### PR TITLE
search fix for special characters

### DIFF
--- a/bot/modules/list.py
+++ b/bot/modules/list.py
@@ -4,12 +4,14 @@ from bot import LOGGER, dispatcher
 from bot.helper.telegram_helper.message_utils import auto_delete_message, sendMessage
 from bot.helper.telegram_helper.filters import CustomFilters
 import threading
+import re
 from bot.helper.telegram_helper.bot_commands import BotCommands
 
 @run_async
 def list_drive(update,context):
     message = update.message.text
     search = message.split(' ',maxsplit=1)[1]
+    search = re.escape(search)
     LOGGER.info(f"Searching: {search}")
     gdrive = GoogleDriveHelper(None)
     msg = gdrive.drive_list(search)

--- a/bot/modules/list.py
+++ b/bot/modules/list.py
@@ -4,14 +4,14 @@ from bot import LOGGER, dispatcher
 from bot.helper.telegram_helper.message_utils import auto_delete_message, sendMessage
 from bot.helper.telegram_helper.filters import CustomFilters
 import threading
-import re
 from bot.helper.telegram_helper.bot_commands import BotCommands
 
 @run_async
 def list_drive(update,context):
     message = update.message.text
     search = message.split(' ',maxsplit=1)[1]
-    search = re.escape(search)
+    if "'"in search:
+        search = search.replace("'", "\\'")
     LOGGER.info(f"Searching: {search}")
     gdrive = GoogleDriveHelper(None)
     msg = gdrive.drive_list(search)


### PR DESCRIPTION
This will fix the error caused during search using special character 😬

Update:
After new commiit..... I have read the api and found out that only "'" or apostrophe should be escaped but my previous commit is escaping all the characters 🤭

So sorry for previous commit...now every search is working fine.
![Screenshot_20200723-114801__01__01](https://user-images.githubusercontent.com/25435568/88257128-b6cc4a80-ccda-11ea-8ced-5d0f2859af6c.jpg)
![Screenshot_20200723-114813__01__01](https://user-images.githubusercontent.com/25435568/88257319-1296d380-ccdb-11ea-882f-ec000f4aba04.jpg)


