### PR TITLE
fix netrc

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,6 @@ ENV LANG en_US.UTF-8
 ENV LANGUAGE en_US:en
 ENV LC_ALL en_US.UTF-8
 COPY . .
-COPY netrc /root/.netrc
 RUN chmod +x aria.sh
 
 CMD ["bash","start.sh"]


### PR DESCRIPTION
bug
- bot.helper.mirror_utils.download_utils.youtube_dl_download_helper - WARNING - parsing .netrc: [Errno 2] No such file or directory: '/usr/src/app/.netrc'

Signed-off-by: HafizZiq <hafizuddinismail552@gmail.com>