### PR TITLE
Fix for youtube dl

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,4 +11,4 @@ python-magic
 beautifulsoup4>=4.8.2,<4.8.10
 Pyrogram>=0.16.0,<0.16.10
 TgCrypto>=1.1.1,<1.1.10
-git+git://github.com/lzzy12/youtube-dl@d7c2b43#youtube_dl
+youtube_dl


### PR DESCRIPTION
Due to youtube dl repo takedown git+git://github.com/lzzy12/youtube-dl@d7c2b43#youtube_dl is not working while replacing it with youtube_dl seems to work as pip install youtube_dl is still up.