### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,4 +11,4 @@ python-magic
 beautifulsoup4>=4.8.2,<4.8.10
 Pyrogram>=0.16.0,<0.16.10
 TgCrypto>=1.1.1,<1.1.10
-youtube_dl
+git+https://github.com/ytdl-org/youtube-dl


### PR DESCRIPTION
Youtube-dl is back again - repository has been restored on GitHub. So we can use it again.