### PR TITLE
Fix restart if user has not mirrored anything

### DIFF
--- a/bot/helper/ext_utils/fs_utils.py
+++ b/bot/helper/ext_utils/fs_utils.py
@@ -23,7 +23,10 @@ def start_cleanup():
 
 def clean_all():
     aria2.remove_all(True)
-    shutil.rmtree(DOWNLOAD_DIR)
+    try:
+        shutil.rmtree(DOWNLOAD_DIR)
+    except FileNotFoundError:
+        pass
 
 
 def exit_clean_up(signal, frame):


### PR DESCRIPTION
I know there is no sense of restart without mirroring anything, but sometimes bot stuck at cloning and there is no way to stop cloning. We have to restart bot. but if we have not mirrored anything it gave error. Just tried to fix it.