### PR TITLE
Skip unavailable videos when downloading from Playlist

### DIFF
--- a/bot/helper/mirror_utils/download_utils/youtube_dl_download_helper.py
+++ b/bot/helper/mirror_utils/download_utils/youtube_dl_download_helper.py
@@ -113,7 +113,7 @@ class YoutubeDLHelper(DownloadHelper):
         if 'entries' in result:
             video = result['entries'][0]
             for v in result['entries']:
-                if v.get('filesize'):
+                if v and v.get('filesize'):
                     self.size += float(v['filesize'])
             # For playlists, ydl.prepare-filename returns the following format: <Playlist Name>-<Id of playlist>.NA
             self.name = name.split(f"-{result['id']}")[0]
@@ -141,6 +141,9 @@ class YoutubeDLHelper(DownloadHelper):
             self.onDownloadError("Download Cancelled by User!")
 
     def add_download(self, link, path, qual):
+        pattern = '^.*(youtu\.be\/|youtube.com\/)(playlist?)'
+        if re.match(pattern, link):
+            self.opts['ignoreerrors'] = True
         self.__onDownloadStart()
         self.extractMetaData(link, qual)
         LOGGER.info(f"Downloading with YT-DL: {link}")


### PR DESCRIPTION
Often YouTube Playlists have some Private videos which cannot be accessed by everyone. When that happens, the bot raises an exception regarding the same. Moreover skipping private videos is not a default behavior of youtube-dl. Therefore I see the idea of skipping the unavailable videos while downloading from a playlist.