### PR TITLE
catch an edge case in gdriveTools.drive_list

### DIFF
--- a/bot/helper/mirror_utils/upload_utils/gdriveTools.py
+++ b/bot/helper/mirror_utils/upload_utils/gdriveTools.py
@@ -433,6 +433,11 @@ class GoogleDriveHelper:
                 if INDEX_URL is not None:
                     url = requests.utils.requote_uri(f'{INDEX_URL}/{file.get("name")}/')
                     msg += f' | <a href="{url}"> Index URL</a>'
+            
+            elif file.get('mimeType') == 'application/vnd.google-apps.shortcut':
+                    msg += f"⁍ <a href='https://drive.google.com/drive/folders/{file.get('id')}'>{file.get('name')}" \
+                        f"</a> (shortcut)"
+                    # Excluded index link as indexes cant download or open these shortcuts
             else:
                 msg += f"⁍ <a href='https://drive.google.com/uc?id={file.get('id')}" \
                        f"&export=download'>{file.get('name')}</a> ({get_readable_file_size(int(file.get('size')))})"


### PR DESCRIPTION
file.get('size') for shortcuts returns NoneType for which int() throws TypeError exception