### PR TITLE
fix for uploading telegram file_name of None type

### DIFF
--- a/bot/modules/mirror.py
+++ b/bot/modules/mirror.py
@@ -53,7 +53,9 @@ class MirrorListener(listeners.MirrorListeners):
             download = download_dict[self.uid]
             name = download.name()
             size = download.size_raw()
-            m_path = f'{DOWNLOAD_DIR}{self.uid}/{download.name()}'
+            if name is None: # when pyrogram's media.file_name is of NoneType
+                name = os.listdir(f'{DOWNLOAD_DIR}{self.uid}')[0]
+            m_path = f'{DOWNLOAD_DIR}{self.uid}/{name}'
         if self.isTar:
             download.is_archiving = True
             try:
@@ -88,8 +90,6 @@ class MirrorListener(listeners.MirrorListeners):
                 LOGGER.info("Not any valid archive, uploading file as it is.")
                 path = f'{DOWNLOAD_DIR}{self.uid}/{name}'
         else:
-            if name is None: # when pyrogram's media.file_name is of NoneType
-                name = os.listdir(f'{DOWNLOAD_DIR}{self.uid}')[0]
             path = f'{DOWNLOAD_DIR}{self.uid}/{name}'
         up_name = pathlib.PurePath(path).name
         LOGGER.info(f"Upload Name : {up_name}")

--- a/bot/modules/mirror.py
+++ b/bot/modules/mirror.py
@@ -88,6 +88,8 @@ class MirrorListener(listeners.MirrorListeners):
                 LOGGER.info("Not any valid archive, uploading file as it is.")
                 path = f'{DOWNLOAD_DIR}{self.uid}/{name}'
         else:
+            if name is None: # when pyrogram's media.file_name is of NoneType
+                name = os.listdir(f'{DOWNLOAD_DIR}{self.uid}')[0]
             path = f'{DOWNLOAD_DIR}{self.uid}/{name}'
         up_name = pathlib.PurePath(path).name
         LOGGER.info(f"Upload Name : {up_name}")


### PR DESCRIPTION
sometimes pyrogram sends media.file_name as None. But download file with [file_name](https://github.com/pyrogram/pyrogram/blob/4f585c156c1a2c6707793a8ad7f2f111515ca23b/pyrogram/methods/messages/download_media.py#L154)

Bot gives Error: `[Errno 2] No such file or directory: '/home/username/mirror-bot/downloads/567/None'`

If you want to reproduce error, I can give you file.